### PR TITLE
Add top customers table to analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,25 @@ You can learn more in the [Create React App documentation](https://facebook.gith
 
 To learn React, check out the [React documentation](https://reactjs.org/).
 
+## Backend API
+
+This project now includes a small Express server with a MySQL connection. The server exposes an example endpoint for retrieving the top customers. Configure your database credentials via the following environment variables:
+
+```
+MYSQL_HOST
+MYSQL_USER
+MYSQL_PASSWORD
+MYSQL_DATABASE
+```
+
+To start the server run:
+
+```bash
+npm run server
+```
+
+The API will be available by default at `http://localhost:4000`.
+
 ### Code Splitting
 
 This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "react-scripts": "5.0.1",
     "recharts": "^2.15.4",
     "sweetalert2": "^11.22.2",
-    "web-vitals": "^5.0.3"
+    "web-vitals": "^5.0.3",
+    "express": "^4.19.2",
+    "mysql2": "^3.9.7",
+    "dotenv": "^16.5.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.21",
@@ -29,7 +32,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "server": "node server/server.js"
   },
   "browserslist": {
     "production": [

--- a/public/sample-certificate.html
+++ b/public/sample-certificate.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sample Certificate</title>
+  <style>
+    body { font-family: Arial, sans-serif; display:flex; justify-content:center; align-items:center; height:100vh; background:#f1f5f9; }
+    .certificate { background:#fff; padding:40px; border:2px solid #0ea5e9; text-align:center; border-radius:8px; }
+    h1 { margin-bottom:20px; color:#0ea5e9; }
+  </style>
+</head>
+<body>
+  <div class="certificate">
+    <h1>Ductless Solutions</h1>
+    <p>This document certifies sample eligibility for special promotional pricing.</p>
+    <p><em>(For demonstration purposes only)</em></p>
+  </div>
+</body>
+</html>

--- a/server/db.js
+++ b/server/db.js
@@ -1,0 +1,15 @@
+const mysql = require('mysql2/promise');
+require('dotenv').config();
+
+// Create the connection pool using environment variables so
+// credentials are not hard-coded in the repository.
+const pool = mysql.createPool({
+  host: process.env.MYSQL_HOST || 'localhost',
+  user: process.env.MYSQL_USER || 'root',
+  password: process.env.MYSQL_PASSWORD || '',
+  database: process.env.MYSQL_DATABASE || 'ductless',
+  waitForConnections: true,
+  connectionLimit: 10,
+});
+
+module.exports = pool;

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const cors = require('cors');
+const pool = require('./db');
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+// Simple endpoint to demonstrate database access.
+app.get('/api/top-customers', async (req, res) => {
+  try {
+    const [rows] = await pool.query(
+      'SELECT name, orders FROM customers ORDER BY orders DESC LIMIT 10'
+    );
+    res.json(rows);
+  } catch (err) {
+    console.error('Error querying MySQL:', err);
+    res.status(500).json({ message: 'Database error' });
+  }
+});
+
+const PORT = process.env.PORT || 4000;
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -19,7 +19,8 @@ const Header = ({ title }) => {
   }, []);
 
   const handleLogout = () => {
-    localStorage.removeItem("tikangToken");
+    // Use the same key that was set on login so the user is actually logged out
+    localStorage.removeItem("ductlessUser");
     navigate('/login');
   };
 

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -18,7 +18,8 @@ const Sidebar = ({ activeTab, setActiveTab }) => {
       confirmButtonText: 'Yes, logout',
     }).then((result) => {
       if (result.isConfirmed) {
-        localStorage.removeItem('tikangToken'); // or your auth token key
+        // Match the login storage key so logout fully clears auth information
+        localStorage.removeItem('ductlessUser');
         Swal.fire('Logged out!', 'You have been logged out.', 'success');
         navigate('/login');
       }

--- a/src/pages/Analytics.jsx
+++ b/src/pages/Analytics.jsx
@@ -21,6 +21,11 @@ const Analytics = () => {
       activeProjects: Math.round(23 * Math.sqrt(multiplier)),
       satisfaction: (4.7 + Math.random() * 0.3).toFixed(1),
       avgProjectValue: Math.round(10850 + Math.random() * 2000),
+      topCustomers: [
+        { name: 'Bryan Davis', orders: Math.round(12 * multiplier) },
+        { name: 'Sarah Johnson', orders: Math.round(9 * multiplier) },
+        { name: 'Mike Wilson', orders: Math.round(7 * multiplier) },
+      ],
     });
   };
 
@@ -140,6 +145,26 @@ const Analytics = () => {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <ChartCard title="Project Status Overview" chartRef={projectStatusRef} />
         <ChartCard title="Geographic Performance" chartRef={geoRef} />
+      </div>
+
+      <div className="bg-white shadow rounded-2xl p-6 mt-8">
+        <h3 className="text-lg font-semibold text-gray-800 mb-4">Top Customers</h3>
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left border-b">
+              <th className="py-2">Customer</th>
+              <th className="py-2 text-right">Orders</th>
+            </tr>
+          </thead>
+          <tbody>
+            {metrics.topCustomers?.map((c, i) => (
+              <tr key={i} className="border-b last:border-0">
+                <td className="py-2">{c.name}</td>
+                <td className="py-2 text-right">{c.orders}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </div>
     </div>
   );

--- a/src/pages/DuctlessLeadForm.jsx
+++ b/src/pages/DuctlessLeadForm.jsx
@@ -93,12 +93,21 @@ export default function DuctlessLeadForm() {
           <div className="w-20 h-20 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-6">
             <CheckCircle className="w-10 h-10 text-green-600" />
           </div>
-          
-          <h2 className="text-3xl font-bold text-gray-800 mb-4">Thank You!</h2>
+
+          <h2 className="text-3xl font-bold text-gray-800 mb-2">Thank You, {formData.firstName}!</h2>
           <p className="text-gray-600 mb-6 text-lg">
             We've received your information and a Ductless Solution specialist will contact you within 24 hours.
           </p>
-          
+
+          <a
+            href="/sample-certificate.html"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block bg-green-600 text-white px-6 py-2 rounded-lg mb-6 hover:bg-green-700 transition-colors"
+          >
+            View Sample Certificate
+          </a>
+
           <div className="bg-blue-50 rounded-lg p-4 mb-6">
             <h3 className="font-semibold text-blue-800 mb-2">What happens next?</h3>
             <ul className="text-sm text-blue-700 space-y-1">
@@ -107,7 +116,7 @@ export default function DuctlessLeadForm() {
               <li>• Energy savings analysis</li>
             </ul>
           </div>
-          
+
           <button
             onClick={handleNewLead}
             className="bg-blue-600 text-white px-8 py-3 rounded-lg hover:bg-blue-700 transition-colors font-medium"


### PR DESCRIPTION
## Summary
- enhance analytics dashboard with a top customers list
- show a sample certificate after lead submission for top prospects
- add basic Express API backed by MySQL

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ea88895d48331807d74fff1579b95